### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
   "name": "Import Volumes in Supervisely format",
   "type": "app",
-  "categories": ["import", "dicom"],
+  "categories": [
+    "import",
+    "dicom"
+  ],
   "description": "Import Supervisely volumes project with annotations",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/B9VUQPv.png",
@@ -14,6 +17,11 @@
   "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
-    "target": ["files_folder", "files_file", "agent_folder", "agent_file"]
+    "target": [
+      "files_folder",
+      "files_file",
+      "agent_folder",
+      "agent_file"
+    ]
   }
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["import", "dicom"],
   "description": "Import Supervisely volumes project with annotations",
-  "docker_image": "supervisely/import-export:6.73.369",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/B9VUQPv.png",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "dicom"
   ],
   "description": "Import Supervisely volumes project with annotations",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/B9VUQPv.png",

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
   "poster": "https://github.com/supervisely-ecosystem/import-volumes-with-anns/assets/57998637/fa40e0e7-c657-45c6-90bf-0ccab5ebb7ba",
   "headless": true,
   "min_agent_version": "6.7.4",
-  "instance_version": "6.12.44",
+  "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
     "target": ["files_folder", "files_file", "agent_folder", "agent_file"]

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.369
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
